### PR TITLE
Fix font loading issue and README url to Résumé

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-See [rick.github.io/resume](http://rick.github.io/resume/).
+See [rick.github.io/resume](https://rick.github.io/resume/).

--- a/_layouts/resume.html
+++ b/_layouts/resume.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href='http://fonts.googleapis.com/css?family=Raleway:400,300,600' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Raleway:400,300,600' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="css/custom.css">
     <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/skeleton.css">

--- a/index.md
+++ b/index.md
@@ -87,4 +87,4 @@ Realistic offers include competitive salary, equity, comprehensive benefits, lib
 
 ----
 
-_This document lives at [rick.github.io/resume](http://rick.github.io/resume/)_
+_This document lives at [rick.github.io/resume](https://rick.github.io/resume/)_


### PR DESCRIPTION
Without this patch Chrome doesn't load the Raleway font since it's over
http.  Github also enforces https when using the default *.github.io
domain.

Finally, update the link in the README since the http link times out.